### PR TITLE
Fixed invalid object being passed

### DIFF
--- a/run.py
+++ b/run.py
@@ -53,5 +53,6 @@ try:
     )
 except Exception as exception:
     print(f'{colorama.Fore.LIGHTYELLOW_EX}An error occurred!\nDetails:{colorama.Fore.LIGHTRED_EX} {exception}')
+    traceback.print_exc()
 
 colorama.deinit()

--- a/src/beastengine/commands/class_commands/class_add.py
+++ b/src/beastengine/commands/class_commands/class_add.py
@@ -31,27 +31,27 @@ files under the 'baseDirectory/subDir' path.{white}
         self.class_files_helper = class_files_helper
 
         if header_only == source_only:
-            self.create_header(class_name, target_config, config.cmake, namespace)
-            self.create_source(class_name, target_config, config.cmake, namespace)
+            self.create_header(class_name, target_config, config, namespace)
+            self.create_source(class_name, target_config, config, namespace)
         elif header_only is True:
-            self.create_header(class_name, target_config, config.cmake, namespace)
+            self.create_header(class_name, target_config, config, namespace)
         elif source_only is True:
-            self.create_source(class_name, target_config, config.cmake, namespace)
+            self.create_source(class_name, target_config, config, namespace)
 
         config.update()
 
-    def create_header(self, class_name, target_config, cmake_config, namespace):
+    def create_header(self, class_name, target_config, config: Config, namespace):
         header_name = self.class_files_helper.create_class_header(
             class_name,
-            self.target_config_manager.get_headers_base_directory(target_config, cmake_config),
+            self.target_config_manager.get_headers_base_directory(target_config, config),
             namespace
         )
         self.target_config_manager.add_file_to_headers_list(header_name, target_config)
 
-    def create_source(self, class_name, target_config, cmake_config, namespace):
+    def create_source(self, class_name, target_config, config: Config, namespace):
         source_name = self.class_files_helper.create_class_source(
             class_name,
-            self.target_config_manager.get_sources_base_directory(target_config, cmake_config),
+            self.target_config_manager.get_sources_base_directory(target_config, config),
             namespace
         )
         self.target_config_manager.add_file_to_sources_list(source_name, target_config)

--- a/src/beastengine/commands/class_commands/class_path_show.py
+++ b/src/beastengine/commands/class_commands/class_path_show.py
@@ -4,7 +4,7 @@ from src.config.target_config_manager import TargetConfigManager
 
 class ClassShowPaths:
     def __init__(self, target_config_manager: TargetConfigManager, config: Config, target_config):
-        headers_base_dir = target_config_manager.get_headers_base_directory(target_config, config.cmake)
-        sources_base_dir = target_config_manager.get_sources_base_directory(target_config, config.cmake)
+        headers_base_dir = target_config_manager.get_headers_base_directory(target_config, config)
+        sources_base_dir = target_config_manager.get_sources_base_directory(target_config, config)
 
         print(f'Headers base directory: {headers_base_dir}\nSources base directory: {sources_base_dir}')

--- a/src/beastengine/commands/class_commands/class_remove.py
+++ b/src/beastengine/commands/class_commands/class_remove.py
@@ -12,7 +12,7 @@ class ClassRemove:
         class_name: str,
         target_config
     ):
-        headers_base_dir = target_config_manager.get_headers_base_directory(target_config, config.cmake)
+        headers_base_dir = target_config_manager.get_headers_base_directory(target_config, config)
         if class_files_helper.does_class_header_file_exist(class_name, headers_base_dir, target_config) is True:
             class_files_helper.remove_class_header_file(class_name, headers_base_dir)
 
@@ -21,7 +21,7 @@ class ClassRemove:
 
             config.update()
 
-        sources_base_dir = target_config_manager.get_sources_base_directory(target_config, config.cmake)
+        sources_base_dir = target_config_manager.get_sources_base_directory(target_config, config)
         if class_files_helper.does_class_source_file_exist(class_name, sources_base_dir, target_config) is True:
             class_files_helper.remove_class_source_file(class_name, sources_base_dir)
 

--- a/src/config/target_config_manager.py
+++ b/src/config/target_config_manager.py
@@ -1,6 +1,7 @@
 import re
 
 from src.beastengine.commands.class_commands.target_cmake_vars_file_opener import TargetCMakeVarsFileOpener
+from src.config.config import Config
 
 
 class TargetConfigManager:
@@ -11,14 +12,14 @@ class TargetConfigManager:
         self.file_opener = file_opener
         self.cmake_var_pattern = re.compile(r'\${[a-zA-Z0-9._-]+\}')
 
-    def get_headers_base_directory(self, target_config, cmake_config):
-        return self.__get_files_base_directory(target_config, cmake_config, target_config['headers'])
+    def get_headers_base_directory(self, target_config, config: Config):
+        return self.__get_files_base_directory(target_config, config, target_config['headers'])
 
-    def get_sources_base_directory(self, target_config, cmake_config):
-        return self.__get_files_base_directory(target_config, cmake_config, target_config['sources'])
+    def get_sources_base_directory(self, target_config, config: Config):
+        return self.__get_files_base_directory(target_config, config, target_config['sources'])
 
-    def __get_files_base_directory(self, target_config, cmake_config, target_files):
-        variables = self.file_opener.open(cmake_config, target_config)
+    def __get_files_base_directory(self, target_config, config: Config, target_files):
+        variables = self.file_opener.open(config, target_config)
 
         base_dir = target_files['base_dir']
         if not base_dir:


### PR DESCRIPTION
The error was caused because code was previously based on `config.cmake` object, but it has changed and it should now be based on `config` standalone object.